### PR TITLE
[PB-443] endret ny-melding lenke fra dokumentvisning

### DIFF
--- a/src/dokument-visning/dokument-visning.js
+++ b/src/dokument-visning/dokument-visning.js
@@ -1,10 +1,10 @@
 import PT from 'prop-types';
 import React from 'react';
+import Lenke from 'nav-frontend-lenker';
+import { FormattedMessage, injectIntl } from 'react-intl';
 import Personalia from './dokumentvisning/personalia/personalia';
 import Dokumenter from './dokumentvisning/dokument/dokumenter';
-import { FormattedMessage, injectIntl } from 'react-intl';
-import Lenke from 'nav-frontend-lenker';
-
+import IntlLenke from "../utils/intl-lenke";
 import './dokument-visning.less';
 
 class DokumentVisning extends React.Component {
@@ -22,8 +22,6 @@ class DokumentVisning extends React.Component {
             printPdfOnClick
         } = this.props;
         const { temakode } = journalpostmetadata.resultat;
-        const kontaktNavUrl = intl.messages['dokumentvisning.kontakt.nav.link'];
-
 
         return (
             <div className="dokinnsyn">
@@ -36,7 +34,9 @@ class DokumentVisning extends React.Component {
                             </Lenke>
                         </li>
                         <li>
-                            <Lenke href={kontaktNavUrl}><FormattedMessage id="dokumentvisning.kontakt.nav" /></Lenke>
+                            <IntlLenke href="skriv.ny.link" className="lenke">
+                                <FormattedMessage id="dokumentvisning.kontakt.nav" />
+                            </IntlLenke>
                         </li>
                     </ul>
                 </section>

--- a/src/mock/resources.json
+++ b/src/mock/resources.json
@@ -54,7 +54,6 @@
   "innboks.avsender": "{ fraBruker, select, true { Melding fra deg } false { Melding fra NAV } other { Ukjent hvem som sendte meldingen }}",
   "status.SAMTALEREFERAT_TELEFON": "Samtalereferat telefon – %s",
   "henvendelse.status.SVAR_TELEFON.ulest": "Svar telefon, sendt",
-  "dokumentvisning.kontakt.nav.link": "https://www.nav.no/no/NAV+og+samfunn/Kontakt+NAV/Kontakt+oss/Skriv+til+oss?kilde=dok",
   "feilmelding.dokumentikketilgjengelig.tittel": "Dokumentet ikke tilgjengelig",
   "innboks.kunne-ikke-hente-meldinger": "Kunne ikke hente dine meldinger",
   "oppgave.0003.fritekst": "Du har en søknad om sykepenger som er klar til å fylles ut",


### PR DESCRIPTION
Byttet til å bruke samme url som andre steder i appen,
da sporing av hvor bruker kommer fra ikke lengre er nødvendig.
Og kan evt løses via Origin/Referrer parametere fra treafik-logg