### PR TITLE
 OPP-1323 : Starte å konsumere rate-limiter fra team namespace

### DIFF
--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -61,3 +61,6 @@ spec:
       value: "https://loginservice.nav.no/login"
     - name: MININNBOKS_URL
       value: "https://mininnboks.nav.no"
+    - name: RATE_LIMITER_URL
+      value: "http://rate-limiter.personoversikt.svc.nais.local"
+

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -61,3 +61,5 @@ spec:
       value: "https://loginservice-q.nav.no/login"
     - name: MININNBOKS_URL
       value: "https://mininnboks.dev.nav.no"
+    - name: RATE_LIMITER_URL
+      value: "http://rate-limiter-{{ namespace }}.personoversikt.svc.nais.local"

--- a/decorator.yaml
+++ b/decorator.yaml
@@ -30,7 +30,7 @@ proxy:
     pingRequestPath: /sosialhjelp/soknad-api/internal/isAlive
 
   - contextPath: /rate-limiter
-    baseUrl: http://rate-limiter.{{ NAIS_NAMESPACE }}.svc.nais.local
+    baseUrl: {{ RATE_LIMITER_URL }}
     pingRequestPath: /rate-limiter/internal/isAlive
 
 redirect:


### PR DESCRIPTION
Endring som skaper styring av rate-limiter url fra decorator.yaml til nais yaml filer og vi er eksplisit i prod miljø at mininnboks skal bruke ratelimiter fra team namespace. Da trenger vi ikke external name service konfig i prod også null downtime side rate-limiter applikasjon er deployet i team namespace før.