### PR TITLE
OPP-1323 : Flytte applikasjon til team namespace

### DIFF
--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -63,4 +63,6 @@ spec:
       value: "https://mininnboks.nav.no"
     - name: RATE_LIMITER_URL
       value: "http://rate-limiter.personoversikt.svc.nais.local"
+    - name: MININNBOKS_API_URL
+      value: "http://mininnboks-api.default.svc.nais.local"
 

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -1,8 +1,8 @@
 apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
-  name: mininnboks
-  namespace: {{ namespace }}
+  name: mininnboks-{{ namespace }}
+  namespace: personoversikt
   cluster: dev-sbs
   labels:
     team: personoversikt
@@ -63,3 +63,5 @@ spec:
       value: "https://mininnboks.dev.nav.no"
     - name: RATE_LIMITER_URL
       value: "http://rate-limiter-{{ namespace }}.personoversikt.svc.nais.local"
+    - name: MININNBOKS_API_URL
+      value: "http://mininnboks-api-{{ namespace }}.personoversikt.svc.nais.local"

--- a/decorator.yaml
+++ b/decorator.yaml
@@ -9,12 +9,12 @@ auth:
 
 proxy:
   - contextPath: /mininnboks-api
-    baseUrl: http://mininnboks-api.{{ NAIS_NAMESPACE }}.svc.nais.local
+    baseUrl: {{ MININNBOKS_API_URL }}
     requestRewrite: REMOVE_CONTEXT_PATH
     pingRequestPath: /internal/isAlive
 
   - contextPath: /mininnboks/tjenester
-    baseUrl: http://mininnboks-api.{{ NAIS_NAMESPACE }}.svc.nais.local
+    baseUrl: {{ MININNBOKS_API_URL }}
     requestRewrite: REMOVE_CONTEXT_PATH
     pingRequestPath: /internal/isAlive
     # må kunne kalle apiet med kun openAM-sesjon


### PR DESCRIPTION
Vi endrer nais config slik at applikasjon skal deployet til teamnamespace(personoversikt) i SBS cluster. Fordel med teamname
kan sjekkes her https://doc.nais.io/clusters/team-namespaces/