### PR TITLE
[KAIZEN-0] Validerer ikke oidc før proxying til saksoversikt

### DIFF
--- a/decorator.yaml
+++ b/decorator.yaml
@@ -23,6 +23,8 @@ proxy:
   - contextPath: /saksoversikt-api
     baseUrl: http://saksoversikt-api.personbruker.svc.nais.local
     pingRequestPath: /saksoversikt-api/internal/isAlive
+    # lar saksoversikt-api håndtere sin egen sikkerhet
+    validateOidcToken: false
 
   - contextPath: /sosialhjelp-soknad-api
     baseUrl: http://sosialhjelp-soknad-api.teamdigisos.svc.nais.local


### PR DESCRIPTION
Ser en del feil av validering av tokens i mininnboks mot saksoversikt-api, uten at det er en åpenbar grunn til dette. 
Skrur av validering, og lar saksoveriskt-api håndtere dette selv istedet. Og forhåpentligvis har de litt bedre logging på tokenvalidering