### PR TITLE
 OPP-1323 : Flytte mininnboks til team namespace i prod

### DIFF
--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -2,7 +2,7 @@ apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
   name: mininnboks
-  namespace: default
+  namespace: personoversikt
   cluster: prod-sbs
   labels:
     team: personoversikt
@@ -64,5 +64,5 @@ spec:
     - name: RATE_LIMITER_URL
       value: "http://rate-limiter.personoversikt.svc.nais.local"
     - name: MININNBOKS_API_URL
-      value: "http://mininnboks-api.default.svc.nais.local"
+      value: "http://mininnboks-api.personoversikt.svc.nais.local"
 


### PR DESCRIPTION
Vi endrer nais config slik at applikasjon skal deployet til teamnamespace(personoversikt) i SBS cluster. Fordel med teamname
kan sjekkes her https://doc.nais.io/clusters/team-namespaces/