### PR TITLE
 [OPP-1340] : håndtere toomanyrequests for ratelimiter fra backend

### DIFF
--- a/src/skriv-nytt-sporsmal/SkrivNyttSporsmal.tsx
+++ b/src/skriv-nytt-sporsmal/SkrivNyttSporsmal.tsx
@@ -75,13 +75,11 @@ function SkrivNyttSporsmal() {
     }
 
     function submitHandler<S>(values: Values<SkrivNyttSporsmalForm>): Promise<any> {
-        return rateLimiter.update().then((isOK) => {
-            if (isOK) {
-                return dispatch(sendSporsmal(temagruppe, values.fritekst, isDirekte));
-            } else {
-                return Promise.reject('rate-limiter feilmelding');
-            }
-        });
+        if (rateLimiter.isOk) {
+            return dispatch(sendSporsmal(temagruppe, values.fritekst, isDirekte));
+        } else {
+            return Promise.reject('rate-limiter feilmelding');
+        }
     }
 
     return (

--- a/src/skriv-nytt-sporsmal/SkrivNyttSporsmalFDAG.tsx
+++ b/src/skriv-nytt-sporsmal/SkrivNyttSporsmalFDAG.tsx
@@ -30,13 +30,11 @@ function SkrivNyttSporsmalFDAG() {
     }
 
     function submitHandler<S>(values: Values<SkrivNyttSporsmalForm>): Promise<any> {
-        return rateLimiter.update().then((isOK) => {
-            if (isOK) {
-                return dispatch(sendSporsmal(Temagruppe.FDAG, values.fritekst, false));
-            } else {
-                return Promise.reject('rate-limiter feilmelding');
-            }
-        });
+        if (rateLimiter.isOk) {
+            return dispatch(sendSporsmal(Temagruppe.FDAG, values.fritekst, false));
+        } else {
+            return Promise.reject('rate-limiter feilmelding');
+        }
     }
 
     return (

--- a/src/skriv-nytt-sporsmal/common.ts
+++ b/src/skriv-nytt-sporsmal/common.ts
@@ -3,10 +3,10 @@ import { Avhengighet } from '../avhengigheter';
 import { AppState } from '../reducer';
 import { ThunkAction } from 'redux-thunk';
 import { useAppState, useThunkDispatch } from '../utils/custom-hooks';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { STATUS } from '../ducks/ducks-utils';
 import { harTilgangTilKommunaleTemagrupper, TilgangState } from '../ducks/tilgang';
-import { sjekkOgOppdaterRatelimiter, sjekkRatelimiter } from '../utils/api';
+import { sjekkRatelimiter } from '../utils/api';
 import { visibleIfHOC } from '../utils/hocs/visible-if';
 import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
 
@@ -58,19 +58,12 @@ export function useTilgangSjekk(): TilgangState {
     return useRestResource((state) => state.tilgang, harTilgangTilKommunaleTemagrupper);
 }
 
-export function useRatelimiter(): { isOk: boolean; update: () => Promise<boolean> } {
+export function useRatelimiter(): { isOk: boolean } {
     const [state, setState] = useState(true);
-    const update = useCallback(() => {
-        const updatedValue = sjekkOgOppdaterRatelimiter();
-        updatedValue.then((isOk) => setState(isOk));
-
-        return updatedValue;
-    }, [setState]);
     useEffect(() => {
         sjekkRatelimiter().then((isOk) => setState(isOk));
-    }, [update]);
-
-    return { isOk: state, update };
+    }, []);
+    return { isOk: state };
 }
 
 export const AlertstripeAdvarselVisibleIf = visibleIfHOC(AlertStripeAdvarsel);


### PR DESCRIPTION
 Når bruker sender spørsmål til mininnboks-api da oppdaterer mininnboks-api ratelimiter. Hvis ratelimiter grensen er nådd da mininnboks-api returnerer 426 http kode. Vi bruker ny action for gjøre render igjen