### PR TITLE
fix/deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16630,9 +16630,9 @@
             }
         },
         "url-parse": {
-            "version": "1.4.7",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-            "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+            "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
             "requires": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"


### PR DESCRIPTION
- Bump url-parse from 1.4.7 to 1.5.1
- Bump color-string from 1.5.4 to 1.5.5
- Bump dns-packet from 1.3.1 to 1.3.4
- Bump hosted-git-info from 2.8.8 to 2.8.9
- Bump lodash from 4.17.20 to 4.17.21
- Bump ssri from 6.0.1 to 6.0.2
- Bump ws from 5.2.2 to 5.2.3
