### PR TITLE
[PROD][KAIZEN-0] legge til to-stegs nedstenging av mininnboks

### DIFF
--- a/src/listevisning/ListeVisning.tsx
+++ b/src/listevisning/ListeVisning.tsx
@@ -24,7 +24,12 @@ const getTraadLister = (traader: Traad[]) => {
 
 const erAktivRegel = (varselId?: string) => (melding: Melding) => melding.korrelasjonsId === varselId;
 
-function ListeVisning(props: { brukerSFSomBackend: boolean }) {
+interface Props {
+    stengtSTO: boolean;
+    brukerSFSomBackend: boolean;
+}
+
+function ListeVisning(props: Props) {
     useBreadcrumbs([]);
     const params = useParams<{ varselId?: string }>();
     const appState = useAppState((state) => state);
@@ -47,7 +52,7 @@ function ListeVisning(props: { brukerSFSomBackend: boolean }) {
     return (
         <article className="blokk-center">
             <Sidetittel className="text-center blokk-l">Innboks</Sidetittel>
-            <VisibleIf visibleIf={!props.brukerSFSomBackend}>
+            <VisibleIf visibleIf={!props.brukerSFSomBackend && !props.stengtSTO}>
                 <div className="text-center blokk-l">
                     <a href={sendNyMeldingURL} className="knapp knapp--hoved">
                         Skriv ny melding

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -19,8 +19,10 @@ console.log('==========================');
 })();
 
 type ToggleMap = { [key: string]: boolean };
-const brukerSalesforceDialoger = true;
+const stengtSTO = false;
+const brukerSalesforceDialoger = false;
 const featureToggles: ToggleMap = {
+    'modia.innboks.steng-sto': stengtSTO,
     'modia.innboks.bruker-salesforce-dialoger': brukerSalesforceDialoger
 };
 

--- a/src/ny-dialog-losning-alerts/ny-dialog-losning.tsx
+++ b/src/ny-dialog-losning-alerts/ny-dialog-losning.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { Systemtittel, Normaltekst } from 'nav-frontend-typografi';
+import { AlertStripeInfo } from 'nav-frontend-alertstriper';
+import { getSfUrl } from "../environment";
+import { visibleIfHOC } from "../utils/hocs/visible-if";
+
+function NyDialogLosning() {
+    const url = getSfUrl();
+    return (
+        <AlertStripeInfo size="4rem" className="blokk-xl">
+            <Systemtittel>Ny innboks er på plass</Systemtittel>
+            <Normaltekst>Dine meldinger er flyttet og kan ses her: <a href={url}>{url}</a></Normaltekst>
+        </AlertStripeInfo>
+    );
+}
+
+export default visibleIfHOC(NyDialogLosning);

--- a/src/ny-dialog-losning-alerts/stengt-sto.tsx
+++ b/src/ny-dialog-losning-alerts/stengt-sto.tsx
@@ -1,17 +1,15 @@
 import * as React from "react";
 import { Systemtittel, Normaltekst } from 'nav-frontend-typografi';
 import { AlertStripeInfo } from 'nav-frontend-alertstriper';
-import { getSfUrl } from "../environment";
 import { visibleIfHOC } from "../utils/hocs/visible-if";
 
-function NyDialogLosning() {
-    const url = getSfUrl();
+function StengtSTO() {
     return (
         <AlertStripeInfo size="4rem" className="blokk-xl">
-            <Systemtittel>Ny dialogløsning etablert</Systemtittel>
-            <Normaltekst>Dine dialoger er flyttet til ny løsning: <a href={url}>{url}</a></Normaltekst>
+            <Systemtittel>Innsending av nye meldinger er midlertidig stengt.</Systemtittel>
+            <Normaltekst>Det jobbes med å flytte all informasjon til ny innboks, det er derfor ikke mulig å sende inn meldinger akkurat nå.</Normaltekst>
         </AlertStripeInfo>
     );
 }
 
-export default visibleIfHOC(NyDialogLosning);
+export default visibleIfHOC(StengtSTO);

--- a/src/traadvisning/TraadVisning.tsx
+++ b/src/traadvisning/TraadVisning.tsx
@@ -16,7 +16,11 @@ import { useBreadcrumbs } from '../brodsmuler/Brodsmuler';
 
 const AlertstripeVisibleIf = visibleIfHOC(Alertstripe);
 
-function TraadVisning() {
+interface Props {
+    stengtSTO: boolean;
+}
+
+function TraadVisning(props: Props) {
     const params = useParams<{ traadId: string }>();
     const skalViseBesvarBoks = useAppState((state) => state.ui.visBesvarBoks);
     const innsendingStatus = useAppState((state) => state.traader.innsendingStatus);
@@ -55,7 +59,7 @@ function TraadVisning() {
                 >
                     Det har skjedd en feil med innsendingen av spørsmålet ditt. Vennligst prøv igjen senere.
                 </AlertstripeVisibleIf>
-                <SkrivKnapp visibleIf={valgttraad.kanBesvares && !skalViseBesvarBoks} onClick={skrivKnappOnClick} />
+                <SkrivKnapp visibleIf={valgttraad.kanBesvares && !skalViseBesvarBoks && !props.stengtSTO} onClick={skrivKnappOnClick} />
                 <AlertstripeVisibleIf type="info" visibleIf={valgttraad.avsluttet ?? false} className="blokk-m">
                     <Normaltekst>
                         Dialogen er avsluttet. Vil du <a href={sendNyMeldingURL}>sende en ny beskjed</a>, kan du gjøre

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -47,9 +47,13 @@ export function useLedetekster(): FetchResult<Ledetekster> {
 
 interface FeatureToggles {
     'modia.innboks.bruker-salesforce-dialoger': boolean;
+    'modia.innboks.steng-sto': boolean;
 }
+const featuretoggles= ['modia.innboks.bruker-salesforce-dialoger', 'modia.innboks.steng-sto']
+    .map((toggle) => `feature=${toggle}`)
+    .join('&');
 export function useFeaturetoggles(): FetchResult<FeatureToggles> {
-    return useFetch<FeatureToggles>('/api/feature?feature=modia.innboks.bruker-salesforce-dialoger', MED_CREDENTIALS)
+    return useFetch<FeatureToggles>(`/api/feature?${featuretoggles}`, MED_CREDENTIALS)
 }
 
 export function hentTraader() {


### PR DESCRIPTION
Introduserer en ny feature-toggle: "modia.innboks.steng-sto" som stenger ned muligheten for å sende inn meldinger fra mininnboks.

"modia.innboks.bruker-salesforce-dialoger" fungerer som tidligere, og hindrer innsending, samt slutter å vise meldinger.

## Oppsummering av funksjonaliet

**Begge feature-toggles er false:** mininnboks vil fungere som før

**steng-sto satt til true:** gir info om midlertidig nedstenging, samt fjerne "ny melding" knappene.
Forsøker man å navigere direkte til "sporsmal/skriv/TEMAGRUPPE" blir man automatisk redirected til fremsiden. Meldingene er fortsatt synlige.
![image](https://user-images.githubusercontent.com/1413417/135444334-54af0edb-874e-47b9-99a7-b860c613ab12.png)
![image](https://user-images.githubusercontent.com/1413417/135444464-29a928aa-9c3d-4f99-85de-c5fbc7c21dba.png)

**bruker-salesforce-dialog satt til true:** gir info om at meldinger er flyttet til ny innboks, fjerner "ny melding" knappene, og slutter å laste inn dialog-meldinger. Det vil nå bare vises varsler i mininnboks. Forsøker man å gå til direkte til "sporsmal/skrive/TEMAGRUPPE" eller /traad/TRAADID" blir man automatisk redirected til fremsiden. Dokumentvisningen vil være eneste gjenstående visning i mininnboks.
![image](https://user-images.githubusercontent.com/1413417/135444970-1ed81a89-243c-421e-8d53-82bc6aa7e430.png)




