### PR TITLE
[PROD] [KAIZEN-0] slutte å gjøre tilgangskontroll for oksos

### DIFF
--- a/src/skriv-nytt-sporsmal/SkrivNyttSporsmal.tsx
+++ b/src/skriv-nytt-sporsmal/SkrivNyttSporsmal.tsx
@@ -20,8 +20,7 @@ import {
     AndreFeilmeldinger,
     FeilmeldingKommunalSjekk,
     SkrivNyttSporsmalForm,
-    useFormstate,
-    useTilgangSjekk
+    useFormstate
 } from './common';
 import './skriv-nytt-sporsmal.less';
 import { useLedetekster } from '../utils/api';
@@ -34,7 +33,6 @@ const spesialtHandterteTemagrupper = [Temagruppe.FDAG];
 function SkrivNyttSporsmal() {
     const dispatch = useThunkDispatch();
     const ledetekster = useLedetekster();
-    const tilgang = useTilgangSjekk();
     const params = useParams<{ temagruppe: Temagruppe }>();
     const temagruppe = params.temagruppe.toUpperCase() as Temagruppe;
     const location = useLocation();
@@ -54,15 +52,9 @@ function SkrivNyttSporsmal() {
     }
 
     if (temagruppe === Temagruppe.OKSOS) {
-        if (tilgang.status === STATUS.PENDING) {
-            return <Spinner />;
-        } else if (tilgang.status === STATUS.ERROR) {
-            return (
-                <Alertstripe type="advarsel">Noe gikk galt, vennligst prøv igjen på ett senere tidspunkt.</Alertstripe>
-            );
-        } else if (tilgang.status === STATUS.OK && tilgang.data.resultat !== 'OK') {
-            return <Alertstripe type="info">{FeilmeldingKommunalSjekk[tilgang.data.resultat]}</Alertstripe>;
-        }
+        return (
+            <Alertstripe type="advarsel">{FeilmeldingKommunalSjekk.IKKE_AKTIV}</Alertstripe>
+        );
     }
 
     const godkjenteTemagrupper = ledetekster.data['temagruppe.liste'].split(' ');

--- a/src/skriv-nytt-sporsmal/common.ts
+++ b/src/skriv-nytt-sporsmal/common.ts
@@ -32,7 +32,8 @@ export const useFormstate = useFormstateFactory(defaultFormstateConfig);
 export enum FeilmeldingKommunalSjekk {
     FEILET = 'Noe gikk galt, vennligst prøv igjen på ett senere tidspunkt.',
     KODE6 = 'Du har dessverre ikke mulighet til å benytte denne løsningen. Vi ber om at du kontakter oss på telefon.',
-    INGEN_ENHET = 'Du har dessverre ikke mulighet til å benytte denne løsningen. Vi ber om at du kontakter oss på telefon.'
+    INGEN_ENHET = 'Du har dessverre ikke mulighet til å benytte denne løsningen. Vi ber om at du kontakter oss på telefon.',
+    IKKE_AKTIV = 'Det er dessverre ikke mulig å sende inn spørsmål på denne temagruppen.'
 }
 
 export enum AndreFeilmeldinger {


### PR DESCRIPTION
temagruppen er stengt ned, og skal ikke være mulig å sende inn på. Det er derfor ikke behov for å gjøre tilgangskontrollen på hvorvidt man har lov til å sende inn.

Fjerner derfor sjekken nå fordi ved endringer av http-client i mininnboks-api ble det introdusert feil som lager mye støy i loggene.
Feilen skal bare påvirke utsending på oksos temagruppen som ikke har vært aktiv siden endringen ble gjort, men det gjør feilsøking av andre feil vanskelig.