### PR TITLE
feat/pensjonist info

### DIFF
--- a/src/skriv-nytt-sporsmal/TemagruppeEkstraInfo.tsx
+++ b/src/skriv-nytt-sporsmal/TemagruppeEkstraInfo.tsx
@@ -20,18 +20,6 @@ type TemagruppeInfo = {
 };
 
 const temagruppeInfo: TemagruppeInfo = {
-    FMLI: [
-        {
-            heading: 'Kontantstøtte: Skal du sende melding om barnehageplass?',
-            intro: <Normaltekst>Vi trenger følgende informasjon fra deg:</Normaltekst>,
-            elementer: [
-                'Fødselsdatoen til barnet',
-                'Navnet på barnehagen',
-                'Fra hvilken dato er barnet tildelt barnehageplass',
-                'Antall timer i uken barnet er tildelt barnehageplass'
-            ]
-        }
-    ],
     PENS: [
         {
             heading: 'Har du spørsmål om AFP-etteroppgjøret?',


### PR DESCRIPTION
- [KAIZEN-0] la til info for pensjonister om AFP
- [KAIZEN-0] fjerne info om aktuelt-info om kontantstøtte for FMLI


![image](https://user-images.githubusercontent.com/1413417/139215500-bcc59dfe-72ec-4034-963f-69504e2d17df.png)
