### PR TITLE
[KAIZEN-0] sette riktig rot for modaler

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,10 +6,11 @@ import MainApp from './mainapp';
 import { render } from 'react-dom';
 import Modal from 'nav-frontend-modal';
 
-Modal.setAppElement('body');
+const rootElement = document.getElementById('app-root');
+Modal.setAppElement(rootElement);
 
 if (process.env.REACT_APP_MOCK_ENABLED === 'true') {
     require('./mock');
 }
 
-render(<MainApp />, document.getElementById('app-root'));
+render(<MainApp />, rootElement);


### PR DESCRIPTION
rot-elementet styrer hva som blir skjult når modalen er åpen. Dette var tidligere body som gjorde at hele siden ble skjult for skjermleser. Mens vi ønsker at modalen fremdeles skal være synlig.

Ved å sette den til `rootElement` så vil hele appen bli skjult når modalen åpnes, men modalen rendes utenfor appen så denne vil være synlig.
