### PR TITLE
[KAIZEN-0] skru av frontendlogger

### DIFF
--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -63,7 +63,7 @@ spec:
       value: "https://mininnboks.nav.no"
     - name: MININNBOKS_API_URL
       value: "http://mininnboks-api.personoversikt.svc.nais.local"
-    - name: FRONTENDLOGGER_URL
-      value: "http://frontendlogger.default.svc.nais.local"
+    - name: DISABLE_FRONTEND_LOGGER
+      value: "true"
     - name: PUBLIC_SF_DIALOG_URL
       value: "https://innboks.nav.no/"

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -63,7 +63,7 @@ spec:
       value: "https://mininnboks.dev.nav.no"
     - name: MININNBOKS_API_URL
       value: "http://mininnboks-api-{{ namespace }}.personoversikt.svc.nais.local"
-    - name: FRONTENDLOGGER_URL
-      value: "http://frontendlogger.{{ namespace }}.svc.nais.local"
+    - name: DISABLE_FRONTEND_LOGGER
+      value: "true"
     - name: PUBLIC_SF_DIALOG_URL
       value: "http://maskert.io"


### PR DESCRIPTION
frontendlogger skal skrus av, og vi ønsker ikke at det spammes ned i våre logger med 404 feil.
